### PR TITLE
Make BigQuery visitas table configurable

### DIFF
--- a/FrontEnd/app/Http/Controllers/FormularioController.php
+++ b/FrontEnd/app/Http/Controllers/FormularioController.php
@@ -41,7 +41,10 @@ class FormularioController extends Controller
         session(['form_id' => $formId]);
 
         // Fetch data from BigQuery
-        $query = 'SELECT * FROM `adoc-bi-dev.OPB.GR_nuevo` WHERE session_id = @session_id';
+        $query = sprintf(
+            'SELECT * FROM `adoc-bi-dev.OPB.%s` WHERE session_id = @session_id',
+            config('admin.bigquery.visitas_table')
+        );
         $queryJobConfig = $this->bigQuery->query($query)->parameters(['session_id' => $formId]);
         $resultados = $this->bigQuery->runQuery($queryJobConfig);
 

--- a/FrontEnd/config/admin.php
+++ b/FrontEnd/config/admin.php
@@ -1,0 +1,10 @@
+<?php
+return [
+    'bigquery' => [
+        'project_id' => env('BIGQUERY_PROJECT_ID', 'adoc-bi-dev'),
+        'dataset' => env('BIGQUERY_ADMIN_DATASET', 'OPB'),
+        'usuarios_table' => env('BIGQUERY_USUARIOS_TABLE', 'usuarios'),
+        'visitas_table' => env('BIGQUERY_VISITAS_TABLE', 'GR_nuevo'),
+        'key_file' => env('BIGQUERY_KEY_FILE', '/claves/adoc-bi-dev-debcb06854ae.json'),
+    ],
+];


### PR DESCRIPTION
## Summary
- add `visitasTable` to the Usuario model
- use the configurable visitas table across queries
- load visitas table in FrontEnd via new `config/admin.php`
- use the config value in FormularioController

## Testing
- `php -l BackEnd/app/Models/Usuario.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b75180fc8329ba4997e5af2b0200