### PR TITLE
Clean debug sections

### DIFF
--- a/BackEnd/app/Http/Controllers/Admin/DashboardController.php
+++ b/BackEnd/app/Http/Controllers/Admin/DashboardController.php
@@ -179,12 +179,14 @@ class DashboardController extends Controller
         session(['admin_dashboard_filtros' => $filtros]);
 
         // DEBUGGING TEMPORAL - REMOVER DESPUÉS
-        Log::info('Filtros procesados', [
-            'filtros' => $filtros,
-            'request_pais' => $request->get('pais'),
-            'request_tienda' => $request->get('tienda'),
-            'user_rol' => $user['rol'] ?? 'no_user'
-        ]);
+        if (config('app.debug')) {
+            Log::info('Filtros procesados', [
+                'filtros' => $filtros,
+                'request_pais' => $request->get('pais'),
+                'request_tienda' => $request->get('tienda'),
+                'user_rol' => $user['rol'] ?? 'no_user'
+            ]);
+        }
 
         return $filtros;
     }

--- a/BackEnd/app/Http/Controllers/Admin/VisitaController.php
+++ b/BackEnd/app/Http/Controllers/Admin/VisitaController.php
@@ -143,9 +143,11 @@ public function imagenes($id)
                     $fileName = basename(parse_url($urlOriginal, PHP_URL_PATH));
                     
                     // Log para debugging
-                    Log::info("Procesando imagen: $columna");
-                    Log::info("URL Original: $urlOriginal");
-                    Log::info("Nombre archivo: $fileName");
+                    if (config('app.debug')) {
+                        Log::info("Procesando imagen: $columna");
+                        Log::info("URL Original: $urlOriginal");
+                        Log::info("Nombre archivo: $fileName");
+                    }
                     
                     // Generar URL firmada válida por 2 horas
                     $object = $bucket->object('observaciones/' . $fileName);
@@ -153,7 +155,9 @@ public function imagenes($id)
                     // Verificar si el objeto existe
                     if ($object->exists()) {
                         $signedUrl = $object->signedUrl(new \DateTime('+2 hours'));
-                        Log::info("URL Firmada generada: $signedUrl");
+                        if (config('app.debug')) {
+                            Log::info("URL Firmada generada: $signedUrl");
+                        }
                         
                         $imagenes[] = [
                             'area' => $columna,
@@ -164,13 +168,17 @@ public function imagenes($id)
                             'existe' => true
                         ];
                     } else {
-                        Log::warning("Archivo no encontrado en bucket: observaciones/$fileName");
+                        if (config('app.debug')) {
+                            Log::warning("Archivo no encontrado en bucket: observaciones/$fileName");
+                        }
                         
                         // Intentar sin la carpeta observaciones
                         $objectDirect = $bucket->object($fileName);
                         if ($objectDirect->exists()) {
                             $signedUrl = $objectDirect->signedUrl(new \DateTime('+2 hours'));
-                            Log::info("URL Firmada (directa) generada: $signedUrl");
+                            if (config('app.debug')) {
+                                Log::info("URL Firmada (directa) generada: $signedUrl");
+                            }
                             
                             $imagenes[] = [
                                 'area' => $columna,
@@ -220,7 +228,9 @@ public function imagenes($id)
             'evaluador' => $visitaRaw['LIDER_ZONA'] ?? $visitaRaw['CORREO_REALIZO']
         ];
 
-        Log::info("Total de imágenes procesadas: " . count($imagenes));
+        if (config('app.debug')) {
+            Log::info("Total de imágenes procesadas: " . count($imagenes));
+        }
 
         return view('admin.visitas.imagenes', compact('imagenes', 'infoVisita'));
 

--- a/BackEnd/routes/web.php
+++ b/BackEnd/routes/web.php
@@ -84,42 +84,43 @@ Route::middleware(['admin.auth'])->group(function () {
 // RUTAS DE DEBUGGING (quitar en producción)
 // ===============================================
 
-Route::get('/test-route', function () {
-    return response()->json([
-        'status' => 'Laravel funcionando correctamente',
-        'timestamp' => now()->toISOString(),
-        'user_authenticated' => session('admin_user') ? true : false,
-        'user_data' => session('admin_user') ? session('admin_user') : null,
-        'session_id' => session()->getId(),
-        'url' => request()->url(),
-        'method' => request()->method()
-    ]);
-})->name('admin.test');
-
-// Ruta para verificar conexión BigQuery
-Route::get('/test-bigquery', function () {
-    try {
-        $usuario = new \App\Models\Usuario();
-        $estadisticas = $usuario->getEstadisticasVisitas();
+if (config('app.debug')) {
+    Route::get('/test-route', function () {
         return response()->json([
-            'status' => 'BigQuery conectado correctamente',
-            'estadisticas' => $estadisticas
+            'status' => 'Laravel funcionando correctamente',
+            'timestamp' => now()->toISOString(),
+            'user_authenticated' => session('admin_user') ? true : false,
+            'user_data' => session('admin_user') ? session('admin_user') : null,
+            'session_id' => session()->getId(),
+            'url' => request()->url(),
+            'method' => request()->method()
         ]);
-    } catch (\Exception $e) {
-        return response()->json([
-            'status' => 'Error en BigQuery',
-            'error' => $e->getMessage()
-        ], 500);
-    }
-})->name('admin.test.bigquery');
+    })->name('admin.test');
 
-// ===============================================
-// RUTAS TEMPORALES PARA LIMPIAR CACHÉ (ELIMINAR DESPUÉS)
-// ===============================================
+    // Ruta para verificar conexión BigQuery
+    Route::get('/test-bigquery', function () {
+        try {
+            $usuario = new \App\Models\Usuario();
+            $estadisticas = $usuario->getEstadisticasVisitas();
+            return response()->json([
+                'status' => 'BigQuery conectado correctamente',
+                'estadisticas' => $estadisticas
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'status' => 'Error en BigQuery',
+                'error' => $e->getMessage()
+            ], 500);
+        }
+    })->name('admin.test.bigquery');
 
-Route::get('/clear-cache', function() {
-    try {
-        $results = [];
+    // ===============================================
+    // RUTAS TEMPORALES PARA LIMPIAR CACHÉ (ELIMINAR DESPUÉS)
+    // ===============================================
+
+    Route::get('/clear-cache', function() {
+        try {
+            $results = [];
         
         // Limpiar caché de rutas
         if (file_exists(base_path('bootstrap/cache/routes-v7.php'))) {
@@ -217,3 +218,4 @@ Route::get('/generate-key', function() {
         'instruction' => 'Copia esta clave y ponla en tu archivo .env como APP_KEY=' . $key
     ]);
 });
+}


### PR DESCRIPTION
## Summary
- gate admin dashboard logging behind app debug setting
- guard debug image logs and debug routes with config('app.debug')

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b790501c8329a7cadd576ff83458