### PR TITLE
Fix BigQuery config usage

### DIFF
--- a/FrontEnd/app/Http/Controllers/FormularioController.php
+++ b/FrontEnd/app/Http/Controllers/FormularioController.php
@@ -242,8 +242,8 @@ class FormularioController extends Controller
 
             // === INSERTAR EN BIGQUERY ===
             $table = $this->bigQuery
-                ->dataset(env('BIGQUERY_DATASET'))
-                ->table(env('BIGQUERY_TABLE'));
+                ->dataset(config('admin.bigquery.dataset'))
+                ->table(config('admin.bigquery.visitas_table'));
 
             $insertResponse = $table->insertRows([['data' => $data]]);
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Control Visitas
+
+Both the FrontEnd and BackEnd use environment variables for BigQuery access.
+Use `BIGQUERY_ADMIN_DATASET` and `BIGQUERY_VISITAS_TABLE` in your `.env` files to
+configure the dataset and table. The `FormularioController` now reads from these
+configurations via `config('admin.bigquery.*')`, ensuring that submissions and
+administration dashboards point to the same dataset and table.


### PR DESCRIPTION
## Summary
- use `config('admin.bigquery.*')` in FormularioController when inserting rows
- add README on BigQuery env variables

## Testing
- `php -l FrontEnd/app/Http/Controllers/FormularioController.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff64a9fd883299fe70bcccae77503